### PR TITLE
add a Container#expiring_upload_url method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 XXX (XXX)
 * Added Raca::Container#temp_upload_url
+* Renamed Raca::Container#expiring_url to Raca::Container#temp_url
+  * the old method still exists for now but is deprecated
 
 v0.3.3 (26th April 2014)
 * Added a User-Agent header to all requests

--- a/README.markdown
+++ b/README.markdown
@@ -112,7 +112,7 @@ is the temp URL key that can be set using Raca::Containers#set_temp_url_key
     ord_containers = account.containers(:ord)
     ord_containers.set_temp_url_key("secret")
     dir = ord_containers.get("container_name")
-    puts dir.expiring_url("remote_key.txt", "secret", Time.now.to_i + 60)
+    puts dir.temp_url("remote_key.txt", "secret", Time.now.to_i + 60)
 
 ### Cloud Servers
 

--- a/lib/raca/container.rb
+++ b/lib/raca/container.rb
@@ -189,8 +189,14 @@ module Raca
     # Generate an expiring URL for downloading a file that is otherwise private.
     # Useful for providing temporary access to files.
     #
-    def expiring_url(object_key, temp_url_key, expires_at = Time.now.to_i + 60)
+    def temp_url(object_key, temp_url_key, expires_at = Time.now.to_i + 60)
       private_url("GET", object_key, temp_url_key, expires_at)
+    end
+
+    # DEPRECATED: use temp_url instead, this will be removed in version 1.0
+    #
+    def expiring_url(object_key, temp_url_key, expires_at = Time.now.to_i + 60)
+      temp_url(object_key, temp_url_key, expires_at)
     end
 
     # Generate a temporary URL for uploading a file to a private container. Anyone

--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -650,17 +650,17 @@ describe Raca::Container do
         cloud_container.cdn_enable(60000).should == true
       end
     end
-    describe '#expiring_url' do
+    describe '#temp_url' do
       context 'when the object name has no spaces' do
         it 'should returned a signed URL' do
-          url = cloud_container.expiring_url("foo.txt", "secret", 1234567890)
+          url = cloud_container.temp_url("foo.txt", "secret", 1234567890)
           expected = "https://the-cloud.com/account/test/foo.txt?temp_url_sig=596355666ef72a9da6b03de32e9dd4ac003ee9be&temp_url_expires=1234567890"
           url.should == expected
         end
       end
       context 'when the object name has a spaces' do
         it 'should returned a signed URL' do
-          url = cloud_container.expiring_url("foo bar.txt", "secret", 1234567890)
+          url = cloud_container.temp_url("foo bar.txt", "secret", 1234567890)
           exp = "https://the-cloud.com/account/test/foo%20bar.txt?temp_url_sig=cf817a7dcd409b40c65da11653a1652b62fe44fe&temp_url_expires=1234567890"
           url.should == exp
         end


### PR DESCRIPTION
Adds experimental support for allowing non-authed users to upload an object to a container. Useful for performing direct uploads from the browser, something that @matthiassiegel is keen to experiment with.
