### PR TITLE
Raca::Account#public_endpoint should support non regioned APIs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ XXX (XXX)
   * the old method still exists for now but is deprecated
 * Expand Raca::Container#metadata to include custom metadata
 * Added raca::Container#set_metadata
+* For non regioned APIs (like Cloud DNS) the region argument to Raca::Account#public_endpoint
+  can be left off
 
 v0.3.3 (26th April 2014)
 * Added a User-Agent header to all requests


### PR DESCRIPTION
- some rackspace cloud APIs (like identity and dns) are not regioned, so
  the second argument to Raca::Account#public_endpoint must be optional
- This is required as I prepare to setup per-app users for our rackspace account. I can create the new users via the control panel, but for fine grained control of their access I will need to use the identity API
