### PR TITLE
avoid reading 4+ Gb files into memory

### DIFF
--- a/lib/raca/container.rb
+++ b/lib/raca/container.rb
@@ -1,6 +1,7 @@
 require 'digest/md5'
 require 'openssl'
 require 'uri'
+require 'raca/windowed_io'
 
 module Raca
 
@@ -291,8 +292,7 @@ module Raca
       while segments.size < segment_count
         start_pos = 0 + (LARGE_FILE_SEGMENT_SIZE * segments.size)
         segment_key = "%s.%03d" % [key, segments.size]
-        io.seek(start_pos)
-        segment_io = StringIO.new(io.read(LARGE_FILE_SEGMENT_SIZE))
+        segment_io = WindowedIO.new(io, start_pos, LARGE_FILE_SEGMENT_SIZE)
         etag = upload_io_standard(segment_key, segment_io, segment_io.size, headers.reject { |k,_v| k == "ETag"})
         segments << {path: "#{@container_name}/#{segment_key}", etag: etag, size_bytes: segment_io.size}
       end

--- a/lib/raca/windowed_io.rb
+++ b/lib/raca/windowed_io.rb
@@ -3,6 +3,10 @@ module Raca
   # Wrap an IO object and expose only a partial subset of the underlying data
   # in an IO-ish interface. Calling code will have access to the window of data
   # starting at 'offset' and the following 'length' bytes.
+  #
+  # This doesn't implement the entire IO contract, just enough to make it work
+  # when handed to Net::HTTP as a request body.
+  #
   class WindowedIO
     def initialize(io, offset, length)
       @io = io

--- a/lib/raca/windowed_io.rb
+++ b/lib/raca/windowed_io.rb
@@ -1,0 +1,68 @@
+module Raca
+
+  # Wrap an IO object and expose only a partial subset of the underlying data
+  # in an IO-ish interface. Calling code will have access to the window of data
+  # starting at 'offset' and the following 'length' bytes.
+  class WindowedIO
+    def initialize(io, offset, length)
+      @io = io
+      @offset = offset
+      if @offset + length > @io.size
+        @length = @io.size - offset
+      else
+        @length = length
+      end
+      @io.seek(@offset)
+    end
+
+    def eof?
+      @io.pos >= @offset + @length
+    end
+
+    def pos
+      @io.pos - @offset
+    end
+
+    def seek(to)
+      if to <= 0
+        @io.seek(@offset)
+      elsif to >= @length
+        @io.seek(@offset + @length)
+      else
+        @io.seek(@offset + to)
+      end
+    end
+
+    def size
+      @length
+    end
+
+    def each(bytes, &block)
+      loop do
+        line = read(bytes)
+        break if line.nil? || line == ""
+        yield line
+      end
+    end
+
+    def read(bytes = 1024)
+      @io.read(capped_bytes_to_read(bytes))
+    end
+
+    def readpartial(bytes = 1024, outbuf = nil)
+      raise EOFError.new("end of file reached") if eof?
+      bytes = capped_bytes_to_read(bytes)
+      @io.readpartial(bytes, outbuf)
+    end
+
+    private
+
+    def capped_bytes_to_read(bytes)
+      if pos + bytes > @length
+        size - pos
+      else
+        bytes
+      end
+    end
+  end
+end

--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -166,21 +166,21 @@ describe Raca::Container do
         before(:each) do
           expect(account).to receive(:http_client).with("the-cloud.com").and_return(storage_client)
           expect(storage_client).to receive(:streaming_put).with(
-            "/account/test/key.000", kind_of(StringIO), 3, 'Content-Type'=>'application/octet-stream', 'ETag' => '900150983cd24fb0d6963f7d28e17f72'
+            "/account/test/key.000", kind_of(Raca::WindowedIO), 3, 'Content-Type'=>'application/octet-stream', 'ETag' => '900150983cd24fb0d6963f7d28e17f72'
           ).and_return(
             Net::HTTPSuccess.new("1.1", 200, "OK").tap { |response|
               response.add_field('ETag', '1')
             }
           )
           expect(storage_client).to receive(:streaming_put).with(
-            "/account/test/key.001", kind_of(StringIO), 3, 'Content-Type'=>'application/octet-stream', 'ETag' => '4ed9407630eb1000c0f6b63842defa7d'
+            "/account/test/key.001", kind_of(Raca::WindowedIO), 3, 'Content-Type'=>'application/octet-stream', 'ETag' => '4ed9407630eb1000c0f6b63842defa7d'
           ).and_return(
             Net::HTTPSuccess.new("1.1", 200, "OK").tap { |response|
               response.add_field('ETag', '2')
             }
           )
           expect(storage_client).to receive(:streaming_put).with(
-            "/account/test/key.002", kind_of(StringIO), 1, 'Content-Type'=>'application/octet-stream', 'ETag' => 'b2f5ff47436671b6e533d8dc3614845d'
+            "/account/test/key.002", kind_of(Raca::WindowedIO), 1, 'Content-Type'=>'application/octet-stream', 'ETag' => 'b2f5ff47436671b6e533d8dc3614845d'
           ).and_return(
             Net::HTTPSuccess.new("1.1", 200, "OK").tap { |response|
               response.add_field('ETag', '3')

--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -166,21 +166,30 @@ describe Raca::Container do
         before(:each) do
           expect(account).to receive(:http_client).with("the-cloud.com").and_return(storage_client)
           expect(storage_client).to receive(:streaming_put).with(
-            "/account/test/key.000", kind_of(Raca::WindowedIO), 3, 'Content-Type'=>'application/octet-stream', 'ETag' => '900150983cd24fb0d6963f7d28e17f72'
+            "/account/test/key.000",
+            kind_of(Raca::WindowedIO),
+            3,
+            {'Content-Type'=>'application/octet-stream', 'ETag' => '900150983cd24fb0d6963f7d28e17f72'}
           ).and_return(
             Net::HTTPSuccess.new("1.1", 200, "OK").tap { |response|
               response.add_field('ETag', '1')
             }
           )
           expect(storage_client).to receive(:streaming_put).with(
-            "/account/test/key.001", kind_of(Raca::WindowedIO), 3, 'Content-Type'=>'application/octet-stream', 'ETag' => '4ed9407630eb1000c0f6b63842defa7d'
+            "/account/test/key.001",
+            kind_of(Raca::WindowedIO),
+            3,
+            {'Content-Type'=>'application/octet-stream', 'ETag' => '4ed9407630eb1000c0f6b63842defa7d'}
           ).and_return(
             Net::HTTPSuccess.new("1.1", 200, "OK").tap { |response|
               response.add_field('ETag', '2')
             }
           )
           expect(storage_client).to receive(:streaming_put).with(
-            "/account/test/key.002", kind_of(Raca::WindowedIO), 1, 'Content-Type'=>'application/octet-stream', 'ETag' => 'b2f5ff47436671b6e533d8dc3614845d'
+            "/account/test/key.002",
+            kind_of(Raca::WindowedIO),
+            1,
+            {'Content-Type'=>'application/octet-stream', 'ETag' => 'b2f5ff47436671b6e533d8dc3614845d'}
           ).and_return(
             Net::HTTPSuccess.new("1.1", 200, "OK").tap { |response|
               response.add_field('ETag', '3')

--- a/spec/windowed_io_spec.rb
+++ b/spec/windowed_io_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe Raca::WindowedIO do
+  let(:source_io) { StringIO.new("0123456789") }
+
+  describe '#pos' do
+    let(:windowed_io) { Raca::WindowedIO.new(source_io, 2, 3)}
+
+    context 'after initialization' do
+      it 'returns 0' do
+        expect(windowed_io.pos).to eq 0
+      end
+    end
+  end
+
+  describe '#size' do
+    let(:windowed_io) { Raca::WindowedIO.new(source_io, 2, 3)}
+
+    context 'with a 3-byte window' do
+      it 'returns 3' do
+        expect(windowed_io.size).to eq 3
+      end
+    end
+  end
+
+  describe 'behaviours' do
+    let(:windowed_io) { Raca::WindowedIO.new(source_io, 2, 3)}
+
+    context 'with a 3-byte window' do
+      it 'behaves as expected while reading single bytes' do
+        expect(windowed_io.pos).to eq 0
+        expect(windowed_io.size).to eq 3
+        expect(windowed_io.read(1)).to eq "2"
+        expect(windowed_io.pos).to eq 1
+        expect(windowed_io.read(1)).to eq "3"
+        expect(windowed_io.pos).to eq 2
+        expect(windowed_io.read(1)).to eq "4"
+        expect(windowed_io.eof?).to be true
+      end
+
+      it 'behaves as expected while reading past the window' do
+        expect(windowed_io.pos).to eq 0
+        expect(windowed_io.size).to eq 3
+        expect(windowed_io.read(4)).to eq "234"
+        expect(windowed_io.pos).to eq 3
+        expect(windowed_io.eof?).to be true
+      end
+
+      it 'behaves as expected while seeking' do
+        expect(windowed_io.pos).to eq 0
+        expect(windowed_io.seek(1))
+        expect(windowed_io.pos).to eq 1
+        expect(windowed_io.read(1)).to eq '3'
+      end
+
+      it 'behaves as expected while seeking to a negative pos' do
+        expect(windowed_io.pos).to eq 0
+        expect(windowed_io.seek(1))
+        expect(windowed_io.pos).to eq 1
+        expect(windowed_io.seek(-1))
+        expect(windowed_io.pos).to eq 0
+      end
+
+      it 'behaves as expected while seeking past the end of the window' do
+        expect(windowed_io.pos).to eq 0
+        expect(windowed_io.seek(5))
+        expect(windowed_io.pos).to eq 3
+        expect(windowed_io.eof?).to be true
+      end
+    end
+
+    context 'with a 3-byte window that passes the end of the source IO' do
+      let(:window_passes_source) { Raca::WindowedIO.new(source_io, 7, 4)}
+
+      it 'behaves as expected while reading past the window' do
+        expect(window_passes_source.pos).to eq 0
+        expect(window_passes_source.size).to eq 3
+        expect(window_passes_source.readpartial(4)).to eq "789"
+        expect(window_passes_source.pos).to eq 3
+        expect(window_passes_source.eof?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
* when uploading a file > 5Gb to cloud files, we break it up into segments of
  of 4Gb
* instead of reading the full 4Gb into memory, wrap the source IO into
  another class that quacks like an IO but only provides access to a
  specific 4Gb window of it